### PR TITLE
Adding AWS Load Balancer Controller and a test

### DIFF
--- a/compute/infra-eks/00-providers.tf
+++ b/compute/infra-eks/00-providers.tf
@@ -17,7 +17,7 @@ provider "helm" {
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
-      args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
     }
   }
 }
@@ -32,7 +32,7 @@ provider "kubectl" {
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
   }
 }
 
@@ -46,18 +46,3 @@ terraform {
 
 data "aws_availability_zones" "available" {}
 data "aws_ecrpublic_authorization_token" "token" {}
-
-# AWS Load Balancer Controller
-
-module "load_balancer_controller" {
-  source = "git::https://github.com/DNXLabs/terraform-aws-eks-lb-controller.git"
-
-  helm_chart_version               = "1.7.2"
-  cluster_identity_oidc_issuer     = module.eks.cluster_oidc_issuer_url
-  cluster_identity_oidc_issuer_arn = module.eks.oidc_provider_arn
-  cluster_name                     = module.eks.cluster_name
-  settings                         = {
-    region: "us-east-1"
-    vpcId: data.terraform_remote_state.infra.outputs.infra_vpc_id
-  }
-}

--- a/compute/infra-eks/00-providers.tf
+++ b/compute/infra-eks/00-providers.tf
@@ -46,3 +46,18 @@ terraform {
 
 data "aws_availability_zones" "available" {}
 data "aws_ecrpublic_authorization_token" "token" {}
+
+# AWS Load Balancer Controller
+
+module "load_balancer_controller" {
+  source = "git::https://github.com/DNXLabs/terraform-aws-eks-lb-controller.git"
+
+  helm_chart_version               = "1.7.2"
+  cluster_identity_oidc_issuer     = module.eks.cluster_oidc_issuer_url
+  cluster_identity_oidc_issuer_arn = module.eks.oidc_provider_arn
+  cluster_name                     = module.eks.cluster_name
+  settings                         = {
+    region: "us-east-1"
+    vpcId: data.terraform_remote_state.infra.outputs.infra_vpc_id
+  }
+}

--- a/compute/infra-eks/main.tf
+++ b/compute/infra-eks/main.tf
@@ -17,9 +17,12 @@ module "eks" {
   cluster_name    = local.name
   cluster_version = "1.29"
 
-  enable_cluster_creator_admin_permissions = true
-  cluster_endpoint_public_access           = true
-  cluster_enabled_log_types                = []
+  # Needed Setting See: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1897
+  create_cluster_primary_security_group_tags = false
+
+  enable_cluster_creator_admin_permissions   = true
+  cluster_endpoint_public_access             = true
+  cluster_enabled_log_types                  = []
   cluster_addons = {
     coredns = {
       configuration_values = jsonencode({

--- a/compute/infra-eks/tests/2048.yaml
+++ b/compute/infra-eks/tests/2048.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: game-2048
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: game-2048
+  name: deployment-2048
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app-2048
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app-2048
+    spec:
+      containers:
+        - image: public.ecr.aws/l6m2t8p7/docker-2048:latest
+          imagePullPolicy: Always
+          name: app-2048
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: game-2048
+  name: service-2048
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: app-2048
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: game-2048
+  name: ingress-2048
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: service-2048
+                port:
+                  number: 80


### PR DESCRIPTION
AWS Load Balancer sets up Load Balancers in private and public subnets. The Test is a deployment of the 2048 game and will test Karpenter node creation and AWS Load Blancer when deployed